### PR TITLE
Update GitHub Actions to current versions and fix CI compatibility

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -36,7 +36,7 @@ jobs:
       run: cmake --build . --target cov_data
 
     - name: Report code coverage
-      uses: zgosalvez/github-actions-report-lcov@v1
+      uses: zgosalvez/github-actions-report-lcov@v7
       with:
         coverage-files: build/cov.info.cleaned
         minimum-coverage: 70

--- a/.github/workflows/deb_package.yml
+++ b/.github/workflows/deb_package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -38,7 +38,7 @@ jobs:
       run: make package
 
     - name: Upload Deb Package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: deb_package
         path: ${{github.workspace}}/build/CppProjectSample-1.0.0-Linux.deb

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -24,7 +24,7 @@ jobs:
             if [ -n "$CPP_SRC_FILES" ]; then clang-format --style=Google -i $CPP_SRC_FILES; fi;
 
       - name: Commit changes
-        uses: Endbug/add-and-commit@v9
+        uses: Endbug/add-and-commit@v10
         with:
             default_author: github_actions
             message: 'Auto Format'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Configure CMake    
       shell: bash
       working-directory: ${{github.workspace}}/build      
-      run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
     - name: Build
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macOS-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/memcheck.yml
+++ b/.github/workflows/memcheck.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Install Valgrind
       run: |
@@ -37,7 +37,7 @@ jobs:
       run: cmake --build . --target valgrind
 
     - name: Upload Memcheck Result
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: memcheck
         path: ${{github.workspace}}/build/memcheck.txt

--- a/.github/workflows/modernize.yml
+++ b/.github/workflows/modernize.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -24,7 +24,7 @@ jobs:
             if [ -n "$CPP_SRC_FILES" ]; then clang-format --style=Google -i $CPP_SRC_FILES; fi;
 
       - name: Commit changes
-        uses: Endbug/add-and-commit@v9
+        uses: Endbug/add-and-commit@v10
         with:
             default_author: github_actions
             message: 'Auto Format'
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Install Clang Tidy
       run: |
@@ -64,7 +64,7 @@ jobs:
       run: rm -rf ${{github.workspace}}/build
 
     - name: Commit changes
-      uses: Endbug/add-and-commit@v9
+      uses: Endbug/add-and-commit@v10
       with:
           default_author: github_actions
           message: 'Auto Clang Tidy Fix'

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/static_check.yml
+++ b/.github/workflows/static_check.yml
@@ -43,7 +43,7 @@ jobs:
                        -export-fixes ${{github.workspace}}/clang-tidy-fixes.yaml
 
     - name: Upload Clang Tidy Result
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: clang_tidy_fixes
         path: ${{github.workspace}}/clang-tidy-fixes.yaml

--- a/.github/workflows/static_check.yml
+++ b/.github/workflows/static_check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -24,7 +24,7 @@ jobs:
       run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
     - name: Upload Compile Commands
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: compile_commands
         path: ${{github.workspace}}/build/compile_commands.json
@@ -55,12 +55,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         submodules: true
 
     - name: Download Compile Commands
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v8
       with:
         name: compile_commands
 
@@ -74,10 +74,10 @@ jobs:
       run: |
           cppcheck --project=${{github.workspace}}/compile_commands.json \
                    --std=c++17 \
-                   --output-file=${{github.workspace}}/cppcheck-report.txt .
+                   --output-file=${{github.workspace}}/cppcheck-report.txt
 
     - name: Upload CppCheck Result
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: cppcheck_report
         path: ${{github.workspace}}/cppcheck-report.txt

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -29,7 +29,7 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE
 
     - name: Upload Tests Executable
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: test_executable
         path: ${{github.workspace}}/build/TestSampleLib
@@ -46,7 +46,7 @@ jobs:
         sudo apt-get install -y valgrind
         
     - name: Download Test Executable
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v8
       with:
         name: test_executable
         
@@ -59,7 +59,7 @@ jobs:
       run: valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --log-file=${{github.workspace}}/valgrind-memcheck.txt ${{github.workspace}}/TestSampleLib
       
     - name: Upload Valgrind Memcheck Result
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: valgrind_memcheck
         path: ${{github.workspace}}/valgrind-memcheck.txt
@@ -76,7 +76,7 @@ jobs:
         sudo apt-get install -y valgrind
         
     - name: Download Test Executable
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v8
       with:
         name: test_executable
         
@@ -89,7 +89,7 @@ jobs:
       run: valgrind --tool=helgrind --log-file=${{github.workspace}}/valgrind-helgrind.txt ${{github.workspace}}/TestSampleLib
       
     - name: Upload Valgrind Helgrind Result
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: valgrind_helgrind
         path: ${{github.workspace}}/valgrind-helgrind.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -43,7 +43,7 @@ jobs:
 
     # Upload SARIF file as an Artifact to download and view
     - name: Upload SARIF as an Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: sarif-file
         path: ${{ steps.run-analysis.outputs.sarif }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Configure CMake    
       shell: bash
       working-directory: ${{github.workspace}}/build      
-      run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -Dgtest_force_shared_crt=TRUE
+      run: cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -Dgtest_force_shared_crt=TRUE -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
     - name: Run MSVC Code Analysis
       uses: microsoft/msvc-code-analysis-action@v0.1.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ if (LCOV_PATH AND GCOV_PATH)
                              '${CMAKE_SOURCE_DIR}/catch2/*'
                              '${CMAKE_SOURCE_DIR}/fakeit/*'
                              '/usr/*'
+                             --ignore-errors unused
                              --output-file ${covname}.info.cleaned
     )
 
@@ -176,6 +177,7 @@ if (LCOV_PATH AND GCOV_PATH)
                                  '${CMAKE_SOURCE_DIR}/catch2/*'
                                  '${CMAKE_SOURCE_DIR}/fakeit/*'
                                  '/usr/*'
+                                 --ignore-errors unused
                                  --output-file ${covname}.info.cleaned
             COMMAND ${GENHTML_PATH} -o ${covname} ${covname}.info.cleaned
             COMMAND ${CMAKE_COMMAND} -E remove ${covname}.info ${covname}.info.cleaned


### PR DESCRIPTION
## Summary

This merge request refreshes the GitHub Actions workflows to supported action versions and fixes CI breakages caused by newer runner/tooling updates.

## What changed

- Updated workflow dependencies from deprecated action versions to current supported releases.
- Upgraded `actions/checkout` from `v3` to `v6` across the workflows.
- Upgraded artifact actions to supported versions:
  - `actions/upload-artifact` to `v7`
  - `actions/download-artifact` to `v8`
- Upgraded `Endbug/add-and-commit` from `v9` to `v10`.
- Upgraded `zgosalvez/github-actions-report-lcov` from `v1` to `v7`.
- Added `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to the macOS and Windows CMake configure steps so the vendored `googletest` CMake files remain compatible with newer CMake 4.x runners.
- Updated LCOV commands in the top-level CMake configuration to ignore `unused` errors during coverage collection.
- Removed the extra trailing `.` from the `cppcheck` command in the static analysis workflow.

## Why

Recent GitHub-hosted runner updates exposed two issues:

- Some workflows still used deprecated artifact action versions, which are now rejected by GitHub Actions.
- Newer macOS and Windows runners use newer CMake versions, and the vendored `googletest` release in this repository still declares an old CMake compatibility level. That caused configure failures until the policy minimum was set explicitly.

## Impact

- Restores compatibility with current GitHub Actions runner images.
- Prevents workflow failures caused by deprecated action versions.
- Allows macOS and Windows CI jobs to configure successfully with the existing vendored `googletest`.
- Makes coverage generation more tolerant of LCOV `unused` warnings.

## Validation

- Reviewed the branch diff against `main`.
- Confirmed the workflow updates cover the affected CI jobs.
- GitHub Actions were not executed from this environment.